### PR TITLE
Fixed bug when URL has no `.git` in it

### DIFF
--- a/open-pr.plugin.zsh
+++ b/open-pr.plugin.zsh
@@ -1,6 +1,6 @@
 #!/bin/sh
 _get_repo() {
-  echo "$1" | sed -e "s/.*github.com[:/]\(.*\)\.git.*/\1/"
+  echo "$1" | sed -e "s/.git$//" -e "s/.*github.com[:/]\(.*\)/\1/"
 }
 
 _build_url() {

--- a/tests/get-repo-test.sh
+++ b/tests/get-repo-test.sh
@@ -6,4 +6,10 @@ assert "_get_repo git@github.com:caarlos0/zsh-open-pr.git" \
 assert "_get_repo https://github.com/caarlos0/zsh-open-pr.git" \
   "caarlos0/zsh-open-pr"
 
+# for #8:
+assert "_get_repo git@github.com:caarlos0/zsh-open-pr" \
+  "caarlos0/zsh-open-pr"
+assert "_get_repo https://github.com/caarlos0/zsh-open-pr" \
+  "caarlos0/zsh-open-pr"
+
 assert_end "_get_repo()"


### PR DESCRIPTION
Fixed forever-living issue when if the remote has no `.git` in the URL,
      the script would simply not work, opening a totally wrong URL in
      the browser.

Fixes #8