### PR TITLE
Improve detection of the target branch

### DIFF
--- a/git-open-pr.sh
+++ b/git-open-pr.sh
@@ -12,6 +12,7 @@ _build_url() {
   repo="$(_get_repo "$origin")"
   pr_url="https://github.com/$repo/pull/new"
   target="$1"
+  test -z "$target" && target=$(git for-each-ref --format='%(upstream:short)' "$(git symbolic-ref -q HEAD)" | cut -d '/' -f 2)
   test -z "$target" && target="master"
   if [ -z "$upstream" ]; then
     echo "$pr_url/$target...$branch"


### PR DESCRIPTION
If the target branch isn't specified in the command arguments, attempts to find the name of the remotly tracked branch (before falling back on `master`).

This means that if the branch `feature` tracks `upstream/dev`, the code will correctly detect that the target branch is `dev`.